### PR TITLE
Add visible_children helper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 0.2.0
 
 Released TBA
 
+- Add ``NavbarEntry.invisible_children`` for easier use inside of templates.
+
 
 Version 0.1.0
 =============

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,4 @@
 doc8
 sphinx
+sphinx_rtd_theme
 sphinxcontrib-napoleon

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,8 +39,8 @@ Quickstart
           <a href="{{ entry.url() }}">
             {{ entry.name }}
           </a>
-          {% if entry.children %}
-            <ul class="dropdown">{{ loop(entry.children) }}</ul>
+          {% if entry.visible_children|list %}
+            <ul class="dropdown">{{ loop(entry.visible_children) }}</ul>
           {% endif %}
         </li>
       {% endfor %}

--- a/flask_copilot/__init__.py
+++ b/flask_copilot/__init__.py
@@ -164,8 +164,13 @@ class NavbarEntry(object):
         if self.when:
             return self.when()
         elif self.children and not self.endpoint:
-            return any(child.visible for child in self.children)
+            return any(self.visible_children)
         return True
+
+    @property
+    def visible_children(self):
+        """Return visible children."""
+        return filter(lambda child: child.visible, self.children)
 
     def url(self, default_href='#'):
         """Return a rendered URL for this entry.


### PR DESCRIPTION
When working with the navbar, it's helpful to know only which children
should be visible. This makes writing the jinja template components
significantly easier.

Additionally, add sphinx_rtd_theme as a docs requirement.
